### PR TITLE
Fixes bootstrap check, preventing unnecessary reloading

### DIFF
--- a/src/handler_loader/handler_loader.cpp
+++ b/src/handler_loader/handler_loader.cpp
@@ -47,7 +47,7 @@ bool HandlerLoader::Bootstrap(XBOXInterface& interface) {
   }
 
   // See if the Dynamic DXT loader is already running.
-  auto request = std::make_shared<HandlerInvokeSimple>("ddxt!hello");
+  auto request = std::make_shared<HandlerInvokeMultiline>("ddxt!hello");
   interface.SendCommandSync(request);
   if (request->IsOK()) {
     return true;


### PR DESCRIPTION
Currently the bootstrap check fails since hello returns a multiline response and the check tests for a single line OK. This causes the bootstrap to be reloaded on every dyndxt interaction.