### PR TITLE
Rename HandlerCommand* to DynDXTCommand*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,8 @@ add_executable(
         src/shell/commands.h
         src/shell/debugger_commands.cpp
         src/shell/debugger_commands.h
-        src/shell/handler_commands.cpp
-        src/shell/handler_commands.h
+        src/shell/dyndxt_commands.cpp
+        src/shell/dyndxt_commands.h
         src/shell/screenshot_converter.cpp
         src/shell/screenshot_converter.h
         src/shell/shell.cpp

--- a/src/shell/dyndxt_commands.cpp
+++ b/src/shell/dyndxt_commands.cpp
@@ -1,4 +1,4 @@
-#include "handler_commands.h"
+#include "dyndxt_commands.h"
 
 #include <fstream>
 
@@ -7,7 +7,7 @@
 #include "handler_loader/handler_requests.h"
 #include "xbox/debugger/xbdm_debugger.h"
 
-Command::Result HandlerCommandLoadBootstrap::operator()(
+Command::Result DynDXTCommandLoadBootstrap::operator()(
     XBOXInterface &interface, const std::vector<std::string> &) {
   auto debugger = interface.Debugger();
   if (!debugger) {
@@ -37,7 +37,7 @@ cleanup:
   return HANDLED;
 }
 
-Command::Result HandlerCommandHello::operator()(
+Command::Result DynDXTCommandHello::operator()(
     XBOXInterface &interface, const std::vector<std::string> &) {
   if (!HandlerLoader::Bootstrap(interface)) {
     std::cout << "Failed to install Dynamic DXT loader.";
@@ -55,7 +55,7 @@ Command::Result HandlerCommandHello::operator()(
   return HANDLED;
 }
 
-Command::Result HandlerCommandInvokeSimple::operator()(
+Command::Result DynDXTCommandInvokeSimple::operator()(
     XBOXInterface &interface, const std::vector<std::string> &args) {
   ArgParser parser(args);
   std::string command;
@@ -79,7 +79,7 @@ Command::Result HandlerCommandInvokeSimple::operator()(
   return HANDLED;
 }
 
-Command::Result HandlerCommandInvokeMultiline::operator()(
+Command::Result DynDXTCommandInvokeMultiline::operator()(
     XBOXInterface &interface, const std::vector<std::string> &args) {
   ArgParser parser(args);
   std::string command;
@@ -103,7 +103,7 @@ Command::Result HandlerCommandInvokeMultiline::operator()(
   return HANDLED;
 }
 
-Command::Result HandlerCommandInvokeSendBinary::operator()(
+Command::Result DynDXTCommandInvokeSendBinary::operator()(
     XBOXInterface &interface, const std::vector<std::string> &args) {
   ArgParser parser(args);
   std::string command;
@@ -150,7 +150,7 @@ Command::Result HandlerCommandInvokeSendBinary::operator()(
   return HANDLED;
 }
 
-Command::Result HandlerCommandInvokeReceiveSizePrefixedBinary::operator()(
+Command::Result DynDXTCommandInvokeReceiveSizePrefixedBinary::operator()(
     XBOXInterface &interface, const std::vector<std::string> &args) {
   ArgParser parser(args);
   std::string command;
@@ -181,7 +181,7 @@ Command::Result HandlerCommandInvokeReceiveSizePrefixedBinary::operator()(
   return HANDLED;
 }
 
-Command::Result HandlerCommandInvokeReceiveKnownSizedBinary::operator()(
+Command::Result DynDXTCommandInvokeReceiveKnownSizedBinary::operator()(
     XBOXInterface &interface, const std::vector<std::string> &args) {
   ArgParser parser(args);
   std::string command;
@@ -217,7 +217,7 @@ Command::Result HandlerCommandInvokeReceiveKnownSizedBinary::operator()(
   return HANDLED;
 }
 
-Command::Result HandlerCommandLoad::operator()(
+Command::Result DynDXTCommandLoad::operator()(
     XBOXInterface &interface, const std::vector<std::string> &args) {
   ArgParser parser(args);
   std::string path;

--- a/src/shell/dyndxt_commands.h
+++ b/src/shell/dyndxt_commands.h
@@ -7,8 +7,8 @@
 
 class XBOXInterface;
 
-struct HandlerCommandLoadBootstrap : Command {
-  HandlerCommandLoadBootstrap()
+struct DynDXTCommandLoadBootstrap : Command {
+  DynDXTCommandLoadBootstrap()
       : Command(
             "\n"
             "Load the XBDM handler injector.") {}
@@ -16,8 +16,8 @@ struct HandlerCommandLoadBootstrap : Command {
                     const std::vector<std::string> &) override;
 };
 
-struct HandlerCommandHello : Command {
-  HandlerCommandHello()
+struct DynDXTCommandHello : Command {
+  DynDXTCommandHello()
       : Command(
             "\n"
             "Verifies that the XBDM handler injector is available.") {}
@@ -25,8 +25,8 @@ struct HandlerCommandHello : Command {
                     const std::vector<std::string> &) override;
 };
 
-struct HandlerCommandInvokeSimple : Command {
-  HandlerCommandInvokeSimple()
+struct DynDXTCommandInvokeSimple : Command {
+  DynDXTCommandInvokeSimple()
       : Command(
             "<processor>!<command> [args]\n"
             "\n"
@@ -36,8 +36,8 @@ struct HandlerCommandInvokeSimple : Command {
                     const std::vector<std::string> &args) override;
 };
 
-struct HandlerCommandInvokeMultiline : Command {
-  HandlerCommandInvokeMultiline()
+struct DynDXTCommandInvokeMultiline : Command {
+  DynDXTCommandInvokeMultiline()
       : Command(
             "<processor>!<command> [args]\n"
             "\n"
@@ -47,8 +47,8 @@ struct HandlerCommandInvokeMultiline : Command {
                     const std::vector<std::string> &args) override;
 };
 
-struct HandlerCommandInvokeSendBinary : Command {
-  HandlerCommandInvokeSendBinary()
+struct DynDXTCommandInvokeSendBinary : Command {
+  DynDXTCommandInvokeSendBinary()
       : Command(
             "<processor>!<command> <binary_path> [args]\n"
             "\n"
@@ -59,8 +59,8 @@ struct HandlerCommandInvokeSendBinary : Command {
                     const std::vector<std::string> &args) override;
 };
 
-struct HandlerCommandInvokeReceiveSizePrefixedBinary : Command {
-  HandlerCommandInvokeReceiveSizePrefixedBinary()
+struct DynDXTCommandInvokeReceiveSizePrefixedBinary : Command {
+  DynDXTCommandInvokeReceiveSizePrefixedBinary()
       : Command(
             "<processor>!<command> <save_path> [args]\n"
             "\n"
@@ -72,8 +72,8 @@ struct HandlerCommandInvokeReceiveSizePrefixedBinary : Command {
                     const std::vector<std::string> &args) override;
 };
 
-struct HandlerCommandInvokeReceiveKnownSizedBinary : Command {
-  HandlerCommandInvokeReceiveKnownSizedBinary()
+struct DynDXTCommandInvokeReceiveKnownSizedBinary : Command {
+  DynDXTCommandInvokeReceiveKnownSizedBinary()
       : Command(
             "<processor>!<command> <save_path> <size_in_bytes> [args]\n"
             "\n"
@@ -85,8 +85,8 @@ struct HandlerCommandInvokeReceiveKnownSizedBinary : Command {
                     const std::vector<std::string> &args) override;
 };
 
-struct HandlerCommandLoad : Command {
-  HandlerCommandLoad()
+struct DynDXTCommandLoad : Command {
+  DynDXTCommandLoad()
       : Command(
             "<dll_path>\n"
             "\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -7,7 +7,7 @@
 
 #include "commands.h"
 #include "debugger_commands.h"
-#include "handler_commands.h"
+#include "dyndxt_commands.h"
 #include "shell_commands.h"
 #include "util/logging.h"
 
@@ -16,13 +16,13 @@ Shell::Shell(std::shared_ptr<XBOXInterface> &interface)
 #define REGISTER(command, handler) \
   commands_[command] = std::make_shared<handler>()
 
-  auto quit = std::make_shared<ShellCommandQuit>();
-  commands_["exit"] = quit;
-  REGISTER("gdb", ShellCommandGDB);
   commands_["help"] = nullptr;
   commands_["?"] = nullptr;
   commands_["!"] = nullptr;
+  REGISTER("gdb", ShellCommandGDB);
   REGISTER("reconnect", ShellCommandReconnect);
+  auto quit = std::make_shared<ShellCommandQuit>();
+  commands_["exit"] = quit;
   commands_["quit"] = quit;
 
   REGISTER("/run", DebuggerCommandRun);
@@ -48,28 +48,24 @@ Shell::Shell(std::shared_ptr<XBOXInterface> &interface)
   commands_["/stepf"] = step_function;
   commands_["/stepfun"] = step_function;
 
-  REGISTER("@bootstrap", HandlerCommandLoadBootstrap);
-  REGISTER("@hello", HandlerCommandHello);
-  REGISTER("@load", HandlerCommandLoad);
-  auto invoke_simple = std::make_shared<HandlerCommandInvokeSimple>();
+  REGISTER("@bootstrap", DynDXTCommandLoadBootstrap);
+  REGISTER("@hello", DynDXTCommandHello);
+  REGISTER("@load", DynDXTCommandLoad);
+  auto invoke_simple = std::make_shared<DynDXTCommandInvokeSimple>();
   commands_["@"] = invoke_simple;
   commands_["@simple"] = invoke_simple;
-
-  auto invoke_multiline = std::make_shared<HandlerCommandInvokeMultiline>();
+  auto invoke_multiline = std::make_shared<DynDXTCommandInvokeMultiline>();
   commands_["@multiline"] = invoke_multiline;
   commands_["@m"] = invoke_multiline;
-
-  auto invoke_sendbin = std::make_shared<HandlerCommandInvokeSendBinary>();
+  auto invoke_sendbin = std::make_shared<DynDXTCommandInvokeSendBinary>();
   commands_["@sendbin"] = invoke_sendbin;
   commands_["@sb"] = invoke_sendbin;
-
   auto invoke_recvbin =
-      std::make_shared<HandlerCommandInvokeReceiveSizePrefixedBinary>();
+      std::make_shared<DynDXTCommandInvokeReceiveSizePrefixedBinary>();
   commands_["@recvbin"] = invoke_recvbin;
   commands_["@rbin"] = invoke_recvbin;
-
   auto invoke_recvbytes =
-      std::make_shared<HandlerCommandInvokeReceiveKnownSizedBinary>();
+      std::make_shared<DynDXTCommandInvokeReceiveKnownSizedBinary>();
   commands_["@recvbytes"] = invoke_recvbytes;
   commands_["@rby"] = invoke_recvbytes;
   commands_["@rbytes"] = invoke_recvbytes;


### PR DESCRIPTION
"Handler" is too generic a name, this renames all the shell processors to a more explicit `DynDXT` prefix.