### PR TITLE
Adds L2 bootloader to speed DDXT loader install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,12 @@ ExternalProject_Add(
         EXCLUDE_FROM_ALL
         BUILD_BYPRODUCTS
         ddxt/lib/bootstrap_l1.asm.obj
+        ddxt/lib/bootstrap_l2.asm.obj
         ddxt/lib/dynamic_dxt_loader.lib
         ddxt/lib/libdynamic_dxt_loader.dll
         ddxt/lib/xbdm.lib
+        CONFIGURE_HANDLED_BY_BUILD TRUE
+        BUILD_ALWAYS TRUE
 )
 ExternalProject_Get_Property(dyndxt_loader INSTALL_DIR)
 set(dyndxt_lib_dir ${INSTALL_DIR}/lib)
@@ -90,6 +93,12 @@ pack_resource(
         ${dyndxt_lib_dir}/bootstrap_l1.asm.obj
         ${GENERATED_FILES_DIR}/bootstrap_l1_xbox.h
         kBootstrapL1
+)
+
+pack_resource(
+        ${dyndxt_lib_dir}/bootstrap_l2.asm.obj
+        ${GENERATED_FILES_DIR}/bootstrap_l2_xbox.h
+        kBootstrapL2
 )
 
 pack_resource(
@@ -197,6 +206,7 @@ add_executable(
         third_party/nxdk/winapi/winnt.h
         third_party/nxdk/xboxkrnl/xboxdef.h
         ${GENERATED_FILES_DIR}/bootstrap_l1_xbox.h
+        ${GENERATED_FILES_DIR}/bootstrap_l2_xbox.h
         ${GENERATED_FILES_DIR}/dynamic_dxt_loader_xbox.h
 )
 

--- a/src/dyndxt_loader/loader.h
+++ b/src/dyndxt_loader/loader.h
@@ -27,15 +27,16 @@ class Loader {
 
   bool LoadDLL(XBOXInterface& interface, const std::string& path);
 
-  // Injects the dynamic dxt loader, returning the address of the entrypoint
-  // method or 0 on error.
-  uint32_t InstallDynamicDXTLoader(
-      const std::shared_ptr<XBDMDebugger>& debugger,
-      const std::shared_ptr<XBDMContext>& context);
+  //! Installs the L2 bootloader.
+  bool InstallL2Loader(const std::shared_ptr<XBDMDebugger>& debugger,
+                       const std::shared_ptr<XBDMContext>& context);
+
+  // Installs the Dynamic DXT loader using the L2 bootloader.
+  bool InstallDynamicDXTLoader(XBOXInterface& interface);
 
   // Invoke the L1 bootstrap to allocate memory. Note that this assumes the
   // `resume` command has already been patched with the L1 bootstrap.
-  [[nodiscard]] uint32_t AllocatePool(
+  [[nodiscard]] uint32_t L1BootstrapAllocatePool(
       const std::shared_ptr<XBDMDebugger>& debugger,
       const std::shared_ptr<XBDMContext>& context, uint32_t size) const;
 

--- a/src/rdcp/rdcp_request.h
+++ b/src/rdcp/rdcp_request.h
@@ -21,7 +21,8 @@ class RDCPRequest {
   virtual void Complete(const std::shared_ptr<RDCPResponse> &response) = 0;
   virtual void Abandon() = 0;
 
-  RDCPResponse::ReadBinarySizeFunc BinaryResponseSizeParser() const {
+  [[nodiscard]] RDCPResponse::ReadBinarySizeFunc BinaryResponseSizeParser()
+      const {
     return binary_response_size_parser_;
   }
 


### PR DESCRIPTION
Adds an L2 bootloader to allow the actual loader to be uploaded via direct binary upload instead of the extremely inefficient `setmem`.

In my test case, this reduces the cold bootloader load time from 27101.6 milliseconds to 6184.16, > 4x faster.
The L2 bootloader could probably be made smaller with some effort (~850 bytes now) but the total time is likely dominated by the actual upload and a massive chain of `getmem2` calls that should likely be disabled during the installation.