### PR TITLE
Modifies debugger launch behavior to be closer to XDK captures.

### DIFF
--- a/src/discovery/discoverer.cpp
+++ b/src/discovery/discoverer.cpp
@@ -136,9 +136,10 @@ close_and_fail:
 bool Discoverer::SendDiscoveryPacket() const {
   NAPPacket packet(NAPPacket::WILDCARD);
   std::vector<uint8_t> buffer = packet.Serialize();
-  struct sockaddr_in addr {
-    .sin_family = AF_INET, .sin_port = XBDM_DISCOVERY_PORT,
-    .sin_addr = {.s_addr = INADDR_BROADCAST},
+  struct sockaddr_in addr{
+      .sin_family = AF_INET,
+      .sin_port = XBDM_DISCOVERY_PORT,
+      .sin_addr = {.s_addr = INADDR_BROADCAST},
   };
 
   ssize_t bytes_sent =
@@ -150,7 +151,7 @@ bool Discoverer::SendDiscoveryPacket() const {
 bool Discoverer::ReceiveResponse(XBDMServer &result) const {
   NAPPacket packet;
   uint8_t buffer[257] = {0};
-  struct sockaddr_in recv_addr {};
+  struct sockaddr_in recv_addr{};
   socklen_t recv_addr_len = sizeof(recv_addr);
 
   ssize_t received =

--- a/src/dyndxt_loader/dxt_library.cpp
+++ b/src/dyndxt_loader/dxt_library.cpp
@@ -19,7 +19,7 @@ typedef struct IMAGE_IMPORT_BY_NAME {
 #define IMAGE_REL_BASED_ABSOLUTE 0
 #define IMAGE_REL_BASED_HIGHLOW 3
 
-#define IMAGE_SNAP_BY_ORDINAL(ordinal) (((ordinal)&0x80000000) != 0)
+#define IMAGE_SNAP_BY_ORDINAL(ordinal) (((ordinal) & 0x80000000) != 0)
 
 DXTLibrary::DXTLibrary(std::shared_ptr<std::istream> is, std::string path)
     : path_(std::move(path)) {

--- a/src/dyndxt_loader/loader.cpp
+++ b/src/dyndxt_loader/loader.cpp
@@ -31,7 +31,6 @@ namespace DynDXTLoader {
 constexpr const char kLoggingTagTracer[] = "DDXTLOADER";
 #define LOG_LOADER(lvl) LOG_TAGGED(lvl, kLoggingTagTracer)
 
-
 static bool SetMemoryUnsafe(const std::shared_ptr<XBDMContext>& context,
                             uint32_t address, const std::vector<uint8_t>& data);
 static bool InvokeL1Bootstrap(const std::shared_ptr<XBDMContext>& context,

--- a/src/dyndxt_loader/xbdm_exports.def.h
+++ b/src/dyndxt_loader/xbdm_exports.def.h
@@ -1,6 +1,6 @@
 #ifdef POPULATE_MAP
 #define DECLARE(base_name, string_name, ordinal) \
-  { "_" string_name, XBDM_##base_name }
+  {"_" string_name, XBDM_##base_name}
 
 #define END ,
 #define LAST_END

--- a/src/dyndxt_loader/xboxkrnl_exports.def.h
+++ b/src/dyndxt_loader/xboxkrnl_exports.def.h
@@ -1,6 +1,6 @@
 #ifdef POPULATE_MAP
 #define DECLARE(base_name, string_name, ordinal) \
-  { "_" string_name, XBOX_##base_name }
+  {"_" string_name, XBOX_##base_name}
 
 #define END ,
 #define LAST_END

--- a/src/net/ip_address.h
+++ b/src/net/ip_address.h
@@ -28,7 +28,7 @@ class IPAddress {
 
  private:
   std::string hostname_;
-  struct sockaddr_in addr_ {};
+  struct sockaddr_in addr_{};
 };
 
 #endif  // XBDM_GDB_BRIDGE_SRC_NET_ADDRESS_H_

--- a/src/net/select_thread.cpp
+++ b/src/net/select_thread.cpp
@@ -7,7 +7,7 @@
 #include "util/logging.h"
 #include "util/timer.h"
 
-void SelectThread::ThreadMainBootstrap(SelectThread *instance) {
+void SelectThread::ThreadMainBootstrap(SelectThread* instance) {
   instance->ThreadMain();
 }
 
@@ -26,7 +26,7 @@ void SelectThread::ThreadMain() {
 
     {
       const std::lock_guard<std::recursive_mutex> lock(connection_lock_);
-      for (auto &connection : connections_) {
+      for (auto& connection : connections_) {
         int conn_max_fd = connection->Select(recv_fds, send_fds, except_fds);
         if (conn_max_fd < 0) {
           continue;
@@ -86,7 +86,14 @@ void SelectThread::Stop() {
   }
 }
 
-void SelectThread::AddConnection(std::shared_ptr<TCPSocketBase> conn) {
+void SelectThread::AddConnection(const std::shared_ptr<TCPSocketBase>& conn) {
   const std::lock_guard<std::recursive_mutex> lock(connection_lock_);
   connections_.emplace_back(conn);
+}
+
+void SelectThread::AddConnection(const std::shared_ptr<TCPSocketBase>& conn,
+                                 std::function<void()> on_close) {
+  const std::lock_guard<std::recursive_mutex> lock(connection_lock_);
+  connections_.emplace_back(conn);
+  close_callbacks_[conn] = std::move(on_close);
 }

--- a/src/net/select_thread.h
+++ b/src/net/select_thread.h
@@ -2,7 +2,9 @@
 #define XBDM_GDB_BRIDGE_SELECTTHREAD_H
 
 #include <atomic>
+#include <functional>
 #include <list>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -16,7 +18,11 @@ class SelectThread {
 
   [[nodiscard]] bool IsRunning() const { return running_; }
 
-  void AddConnection(std::shared_ptr<TCPSocketBase> conn);
+  void AddConnection(const std::shared_ptr<TCPSocketBase>& conn);
+  //! Registers the given connection along with a callback function to be
+  //! invoked when the connection is closed.
+  void AddConnection(const std::shared_ptr<TCPSocketBase>& conn,
+                     std::function<void()> on_close);
 
  private:
   void ThreadMain();
@@ -28,6 +34,9 @@ class SelectThread {
 
   std::recursive_mutex connection_lock_;
   std::list<std::shared_ptr<TCPSocketBase>> connections_;
+
+  std::map<std::shared_ptr<TCPSocketBase>, std::function<void()>>
+      close_callbacks_;
 };
 
 #endif  // XBDM_GDB_BRIDGE_SELECTTHREAD_H

--- a/src/net/tcp_server.cpp
+++ b/src/net/tcp_server.cpp
@@ -18,7 +18,7 @@ bool TCPServer::Listen(const IPAddress &address) {
   }
 
   const struct sockaddr_in &addr = address.Address();
-  struct sockaddr_in bind_addr {};
+  struct sockaddr_in bind_addr{};
   socklen_t bind_addr_len = sizeof(bind_addr);
 
   int enabled = 1;
@@ -96,7 +96,7 @@ bool TCPServer::Process(const fd_set &read_fds, const fd_set &write_fds,
   }
 
   if (FD_ISSET(socket_, &read_fds)) {
-    struct sockaddr_in bind_addr {};
+    struct sockaddr_in bind_addr{};
     socklen_t bind_addr_len = sizeof(bind_addr);
 
     int accepted_socket =

--- a/src/net/tcp_socket_base.h
+++ b/src/net/tcp_socket_base.h
@@ -7,6 +7,7 @@
 
 class TCPSocketBase {
  public:
+  virtual ~TCPSocketBase() = default;
   explicit TCPSocketBase(std::string name, int sock = -1)
       : name_(std::move(name)), socket_(sock) {}
   TCPSocketBase(std::string name, int sock, IPAddress address)

--- a/src/rdcp/rdcp_request.h
+++ b/src/rdcp/rdcp_request.h
@@ -12,6 +12,7 @@
 
 class RDCPRequest {
  public:
+  virtual ~RDCPRequest() = default;
   explicit RDCPRequest(std::string command) : command_(std::move(command)) {}
   RDCPRequest(std::string command, std::vector<uint8_t> data)
       : command_(std::move(command)), data_(std::move(data)) {}
@@ -54,6 +55,18 @@ class RDCPRequest {
     if (data) {
       data_.insert(data_.end(), data, data + strlen(data));
     }
+  }
+
+  void AppendDecimalString(int value) {
+    char buf[32] = {0};
+    snprintf(buf, 31, "%d", value);
+    data_.insert(data_.end(), buf, buf + strlen(buf));
+  }
+
+  void AppendDecimalString(unsigned int value) {
+    char buf[32] = {0};
+    snprintf(buf, 31, "%u", value);
+    data_.insert(data_.end(), buf, buf + strlen(buf));
   }
 
   template <

--- a/src/rdcp/xbdm_requests.h
+++ b/src/rdcp/xbdm_requests.h
@@ -1278,7 +1278,7 @@ struct NotifyAt : public RDCPProcessedRequest {
                     bool debug_flag = false)
       : RDCPProcessedRequest("notifyat"), port(port) {
     SetData(" Port=");
-    AppendHexString(port);
+    AppendDecimalString(port);
     if (drop_flag) {
       AppendData(" drop");
     }


### PR DESCRIPTION
* Introduces more graceful shutdown of connection when triggering remote reboot.
* Prevents unnecessary reconnect after remote reboot.
* Bonus: Fixes some clang-tidy warnings.