### PR TITLE
Tests array dereferencing in getmem command.

### DIFF
--- a/src/shell/commands.cpp
+++ b/src/shell/commands.cpp
@@ -106,7 +106,7 @@ Command::Result CommandBreak::operator()(XBOXInterface& interface,
       PrintUsage();
       return HANDLED;
     }
-    int32_t size = 1;
+    int32_t size = 4;
     parser.Parse(1, size);
     UpdateCondition(XBDMDebugger::BreakpointType::READ_WATCH, address, clear);
     SendAndPrintMessage(
@@ -121,7 +121,7 @@ Command::Result CommandBreak::operator()(XBOXInterface& interface,
       PrintUsage();
       return HANDLED;
     }
-    int32_t size = 1;
+    int32_t size = 4;
     parser.Parse(1, size);
     UpdateCondition(XBDMDebugger::BreakpointType::WRITE_WATCH, address, clear);
     SendAndPrintMessage(

--- a/test/shell/test_commands.cpp
+++ b/test/shell/test_commands.cpp
@@ -163,4 +163,39 @@ DEBUGGER_TEST_CASE(GetMemSupportsDereferencingRegisterExpressionsInAddress) {
                     "ff ee 44 11 22 33 88 99 01 02 03 04 a0 a1 a2 a3 ");
 }
 
+DEBUGGER_TEST_CASE(
+    GetMemSupportsArrayDereferencingRegisterExpressionsInAddress) {
+  std::vector<uint8_t> pointer_data{
+      0x45,
+      0x23,
+      0x01,
+      0x00,
+  };
+
+  std::vector<uint8_t> data{
+      0xFF, 0xEE, 0x44, 0x11, 0x22, 0x33, 0x88, 0x99,
+      0x01, 0x02, 0x03, 0x04, 0xA0, 0xA1, 0xA2, 0xA3,
+  };
+  server->AddRegion(0x20004, pointer_data);
+  server->AddRegion(0x12345, data);
+  std::stringstream capture;
+  CommandGetMem cmd;
+  ArgParser args("getmem @$eax[4] 16");
+  ThreadContext thread_context;
+  thread_context.eax = 0x20000;
+  auto memory_reader =
+      [&](uint32_t addr,
+          uint32_t size) -> std::expected<std::vector<uint8_t>, std::string> {
+    return server->GetMemoryRegion(addr, size);
+  };
+
+  interface->SetExpressionParser(std::make_shared<DebuggerExpressionParser>(
+      thread_context, std::nullopt, memory_reader));
+
+  BOOST_REQUIRE(cmd(*interface, args, capture) == Command::HANDLED);
+
+  BOOST_CHECK_EQUAL(Trimmed(capture),
+                    "ff ee 44 11 22 33 88 99 01 02 03 04 a0 a1 a2 a3 ");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Bonus, fixes default read/write watchpoint sizes.