### PR TITLE
Adds performance counter shell commands.

### DIFF
--- a/src/rdcp/xbdm_requests.h
+++ b/src/rdcp/xbdm_requests.h
@@ -1927,7 +1927,7 @@ struct QueryPerformanceCounter : public RDCPProcessedRequest {
     }
 
     auto parsed = RDCPMultiMapResponse(response->Data());
-    parsed_maps = parsed.maps;
+    parsed_maps = std::move(parsed.maps);
   }
 
   std::vector<RDCPMapResponse> parsed_maps;

--- a/src/rdcp/xbdm_requests.h
+++ b/src/rdcp/xbdm_requests.h
@@ -1916,6 +1916,21 @@ struct QueryPerformanceCounter : public RDCPProcessedRequest {
     AppendData("\" type=");
     AppendHexString(counter_type);
   }
+
+  [[nodiscard]] bool IsOK() const override {
+    return status == StatusCode::OK_MULTILINE_RESPONSE;
+  }
+
+  void ProcessResponse(const std::shared_ptr<RDCPResponse>& response) override {
+    if (!IsOK()) {
+      return;
+    }
+
+    auto parsed = RDCPMultiMapResponse(response->Data());
+    parsed_maps = parsed.maps;
+  }
+
+  std::vector<RDCPMapResponse> parsed_maps;
 };
 
 /**

--- a/src/shell/commands.cpp
+++ b/src/shell/commands.cpp
@@ -767,7 +767,7 @@ Command::Result CommandListPerfCounters::operator()(XBOXInterface& interface,
   } else {
     for (auto& counter : request->counters) {
       out << std::left << std::setw(32) << counter.name << " 0x" << std::hex
-          << counter.type << std::endl;
+          << counter.type << std::dec << std::endl;
     }
   }
   return HANDLED;

--- a/src/shell/commands.cpp
+++ b/src/shell/commands.cpp
@@ -243,6 +243,21 @@ Command::Result CommandDelete::operator()(XBOXInterface& interface,
   return HANDLED;
 }
 
+Command::Result CommandEnablePerfCounters::operator()(XBOXInterface& interface,
+                                                      const ArgParser& args,
+                                                      std::ostream& out) {
+  SendAndPrintMessage(interface, std::make_shared<EnableGPUCounter>(true), out);
+  return HANDLED;
+}
+
+Command::Result CommandDisablePerfCounters::operator()(XBOXInterface& interface,
+                                                       const ArgParser& args,
+                                                       std::ostream& out) {
+  SendAndPrintMessage(interface, std::make_shared<EnableGPUCounter>(false),
+                      out);
+  return HANDLED;
+}
+
 Command::Result CommandDirList::operator()(XBOXInterface& interface,
                                            const ArgParser& args,
                                            std::ostream& out) {

--- a/src/shell/commands.cpp
+++ b/src/shell/commands.cpp
@@ -757,6 +757,22 @@ Command::Result CommandIsStopped::operator()(XBOXInterface& interface,
   return HANDLED;
 }
 
+Command::Result CommandListPerfCounters::operator()(XBOXInterface& interface,
+                                                    const ArgParser& args,
+                                                    std::ostream& out) {
+  auto request = std::make_shared<PerformanceCounterList>();
+  interface.SendCommandSync(request);
+  if (!request->IsOK()) {
+    out << *request << std::endl;
+  } else {
+    for (auto& counter : request->counters) {
+      out << std::left << std::setw(32) << counter.name << " 0x" << std::hex
+          << counter.type << std::endl;
+    }
+  }
+  return HANDLED;
+}
+
 Command::Result CommandMagicBoot::operator()(XBOXInterface& interface,
                                              const ArgParser& args,
                                              std::ostream& out) {

--- a/src/shell/commands.cpp
+++ b/src/shell/commands.cpp
@@ -986,6 +986,35 @@ Command::Result CommandPutFile::operator()(XBOXInterface& interface,
   return HANDLED;
 }
 
+Command::Result CommandQueryPerfCounters::operator()(XBOXInterface& interface,
+                                                     const ArgParser& args,
+                                                     std::ostream& out) {
+  std::string name;
+  if (!args.Parse(0, name)) {
+    out << "Missing required name argument." << std::endl;
+    PrintUsage();
+    return HANDLED;
+  }
+
+  std::shared_ptr<QueryPerformanceCounter> request;
+  int type;
+  if (args.Parse(1, type, interface.GetExpressionParser())) {
+    request = std::make_shared<QueryPerformanceCounter>(name, type);
+  } else {
+    request = std::make_shared<QueryPerformanceCounter>(name);
+  }
+
+  interface.SendCommandSync(request);
+  if (!request->IsOK()) {
+    out << *request << std::endl;
+  } else {
+    for (const auto& map : request->parsed_maps) {
+      out << map << std::endl;
+    }
+  }
+  return HANDLED;
+}
+
 Command::Result CommandRename::operator()(XBOXInterface& interface,
                                           const ArgParser& args,
                                           std::ostream& out) {

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -137,6 +137,18 @@ struct CommandDelete : Command {
                     std::ostream& out) override;
 };
 
+struct CommandEnablePerfCounters : Command {
+  CommandEnablePerfCounters() : Command("Enable performance counters.") {}
+  Result operator()(XBOXInterface& interface, const ArgParser& args,
+                    std::ostream& out) override;
+};
+
+struct CommandDisablePerfCounters : Command {
+  CommandDisablePerfCounters() : Command("Disable performance counters.") {}
+  Result operator()(XBOXInterface& interface, const ArgParser& args,
+                    std::ostream& out) override;
+};
+
 struct CommandDirList : Command {
   CommandDirList()
       : Command("List details of a file or directory.",

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -323,6 +323,13 @@ struct CommandIsStopped : Command {
                     std::ostream& out) override;
 };
 
+struct CommandListPerfCounters : Command {
+  CommandListPerfCounters()
+      : Command("List all available performance counters.") {}
+  Result operator()(XBOXInterface& interface, const ArgParser& args,
+                    std::ostream& out) override;
+};
+
 struct CommandMagicBoot : Command {
   CommandMagicBoot()
       : Command("Reboot into an XBE.",

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -434,6 +434,16 @@ struct CommandPutFile : Command {
                     std::ostream& out) override;
 };
 
+struct CommandQueryPerfCounters : Command {
+  CommandQueryPerfCounters()
+      : Command("Query a performance counter.",
+                "<name> [type]\n"
+                "\n"
+                "Query the value of the specified performance counter.") {}
+  Result operator()(XBOXInterface& interface, const ArgParser& args,
+                    std::ostream& out) override;
+};
+
 struct CommandRename : Command {
   CommandRename()
       : Command("Rename/move a path on the target.",

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -188,6 +188,10 @@ Shell::Shell(std::shared_ptr<XBOXInterface>& interface)
   REGISTER("notifyat", CommandNotifyAt);
   REGISTER("mv", CommandRename);
   REGISTER("putfile", CommandPutFile);
+  REGISTER("queryperfcounters", CommandQueryPerfCounters);
+  ALIAS("queryperfcounters", "pcquery");
+  ALIAS("queryperfcounters", "querypc");
+  ALIAS("queryperfcounters", "qpc");
   REGISTER("reboot", CommandReboot);
   REGISTER("resume", CommandResume);
   REGISTER("screenshot", CommandScreenshot);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -172,6 +172,9 @@ Shell::Shell(std::shared_ptr<XBOXInterface>& interface)
   REGISTER("isbreak", CommandIsBreak);
   REGISTER("isdebugger", CommandIsDebugger);
   REGISTER("isstopped", CommandIsStopped);
+  REGISTER("listperfcounters", CommandListPerfCounters);
+  ALIAS("listperfcounters", "pclist");
+  ALIAS("listperfcounters", "listpc");
   REGISTER("run", CommandMagicBoot);
   auto mem_map = std::make_shared<CommandMemoryMap>();
   commands_["memorymap"] = mem_map;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -148,6 +148,14 @@ Shell::Shell(std::shared_ptr<XBOXInterface>& interface)
   REGISTER("dedicate", CommandDedicate);
   REGISTER("dmversion", CommandDebugMonitorVersion);
   REGISTER("rm", CommandDelete);
+  REGISTER("disableperfcounters", CommandDisablePerfCounters);
+  ALIAS("disableperfcounters", "disablepc");
+  ALIAS("disableperfcounters", "pcdisable");
+  ALIAS("disableperfcounters", "pcoff");
+  REGISTER("enableperfcounters", CommandEnablePerfCounters);
+  ALIAS("enableperfcounters", "enablepc");
+  ALIAS("enableperfcounters", "pcenable");
+  ALIAS("enableperfcounters", "pcon");
   REGISTER("ls", CommandDirList);
   REGISTER("df", CommandDriveFreeSpace);
   REGISTER("drivelist", CommandDriveList);


### PR DESCRIPTION
The CPU based counters can be queried, the GPU counters need to be enabled but there must be some precondition that needs to be met as the enable command always fails.